### PR TITLE
Update install.yml

### DIFF
--- a/roles/influxdb/tasks/install.yml
+++ b/roles/influxdb/tasks/install.yml
@@ -4,7 +4,7 @@
   when: ansible_distribution in ('RedHat', 'CentOS', 'Scientific')
 
 - name: get package of influxdb from official
-  get_url: url=http://s3.amazonaws.com/influxdb/influxdb_latest_amd64.deb
+  get_url: url=http://s3.amazonaws.com/influxdb/influxdb_0.9.5-s1_amd64.deb
            dest=/tmp/influxdb_latest_amd64.deb
 
 - name: install deb package of influxdb from official


### PR DESCRIPTION
influxdb_latest is unavailable on s3, changed to last version available on s3 server, if you have a new version please change this to right version.
